### PR TITLE
change "of" with "di" in page numbering

### DIFF
--- a/Padova/beamerouterthemePadova.sty
+++ b/Padova/beamerouterthemePadova.sty
@@ -50,7 +50,7 @@
 		\pgftext[right,bottom,at=\pgfpoint{\paperwidth}{0cm}]{\pgfuseimage{pageBackground}}
 		\pgftext[right,bottom,at=\pgfpoint{0.98\paperwidth}{0.02\paperwidth}]{
 			\usebeamerfont{frame number in foot}
-			\usebeamercolor[fg]{frame number in foot}\insertframenumber{} of \inserttotalframenumber
+			\usebeamercolor[fg]{frame number in foot}\insertframenumber{} di \inserttotalframenumber
 		}
 	\fi
 }


### PR DESCRIPTION
Nel numero di pagina non viene più mostrato `[#slide] of [#totale]` ma `[#slide] di [#totale]`visto che abbiamo le slides in italiano